### PR TITLE
Fix start pattern for github flavored markdown code blocks

### DIFF
--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -48,7 +48,7 @@ endfunction
 " Opens up a new proxy buffer with the contents of a fenced code block in
 " github-flavoured markdown.
 function! inline_edit#MarkdownFencedCode()
-  let start_pattern = '^\s*``` \(.\+\)'
+  let start_pattern = '^\s*```\s*\(.\+\)'
   let end_pattern   = '^\s*```\s*$'
 
   call inline_edit#PushCursor()


### PR DESCRIPTION
- See: http://github.github.com/github-flavored-markdown/ - Syntax
  highlighting
- A space between ``` and file type is not needed
