### PR TITLE
Add suport for Vue files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,4 +111,29 @@ If you like the plugin, consider rating it on [vim.org](http://www.vim.org/scrip
   PYTHON
   ```
 
+- Vue Single File Components
+
+  ```vue
+  <template>
+    <p>{{ greeting }} World!</p>
+  </template>
+
+  <script>
+  module.exports = {
+    data: function () {
+      return {
+        greeting: 'Hello'
+      }
+    }
+  }
+  </script>
+
+  <style scoped>
+  p {
+    font-size: 2em;
+    text-align: center;
+  }
+  </style>
+  ```
+
 - Visual mode - any area that you mark

--- a/example/example.vue
+++ b/example/example.vue
@@ -1,0 +1,20 @@
+<template>
+  <p>{{ greeting }} World!</p>
+</template>
+
+<script>
+module.exports = {
+  data: function () {
+    return {
+      greeting: 'Hello'
+    }
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+  text-align: center;
+}
+</style>

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -58,7 +58,7 @@ call add(g:inline_edit_patterns, {
       \ 'main_filetype':     'vue',
       \ 'sub_filetype':      'html',
       \ 'indent_adjustment': 1,
-      \ 'start':             '<template>',
+      \ 'start':             '<template\>[^>]*>',
       \ 'end':               '</template>'
       \ })
 

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -55,6 +55,27 @@ call add(g:inline_edit_patterns, {
       \ })
 
 call add(g:inline_edit_patterns, {
+      \     'main_filetype': 'vue',
+      \     'sub_filetype':  'html',
+      \     'start':         '<template>',
+      \     'end':           '</template>'
+      \ })
+
+call add(g:inline_edit_patterns, {
+      \     'main_filetype': 'vue',
+      \     'sub_filetype':  'javascript',
+      \     'start':         '<script>',
+      \     'end':           '</script>'
+      \ })
+
+call add(g:inline_edit_patterns, {
+      \     'main_filetype': 'vue',
+      \     'sub_filetype':  'css',
+      \     'start':         '<style\>[^>]*>',
+      \     'end':           '</style>'
+      \ })
+
+call add(g:inline_edit_patterns, {
       \ 'main_filetype':     '*html',
       \ 'sub_filetype':      'javascript',
       \ 'indent_adjustment': 1,

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -55,24 +55,11 @@ call add(g:inline_edit_patterns, {
       \ })
 
 call add(g:inline_edit_patterns, {
-      \     'main_filetype': 'vue',
-      \     'sub_filetype':  'html',
-      \     'start':         '<template>',
-      \     'end':           '</template>'
-      \ })
-
-call add(g:inline_edit_patterns, {
-      \     'main_filetype': 'vue',
-      \     'sub_filetype':  'javascript',
-      \     'start':         '<script>',
-      \     'end':           '</script>'
-      \ })
-
-call add(g:inline_edit_patterns, {
-      \     'main_filetype': 'vue',
-      \     'sub_filetype':  'css',
-      \     'start':         '<style\>[^>]*>',
-      \     'end':           '</style>'
+      \ 'main_filetype':     'vue',
+      \ 'sub_filetype':      'html',
+      \ 'indent_adjustment': 1,
+      \ 'start':             '<template>',
+      \ 'end':               '</template>'
       \ })
 
 call add(g:inline_edit_patterns, {
@@ -113,7 +100,7 @@ function! s:InlineEdit(count, filetype)
       if has_key(entry, 'main_filetype')
         if entry.main_filetype == '*html'
           " treat "*html" as a special case
-          let filetypes = ['html', 'eruby', 'php', 'eco'] + g:inline_edit_html_like_filetypes
+          let filetypes = ['html', 'eruby', 'php', 'eco', 'vue'] + g:inline_edit_html_like_filetypes
           let pattern_filetype = join(filetypes, '\|')
         else
           let pattern_filetype = entry.main_filetype


### PR DESCRIPTION
Hello, here's my attempt at adding support for Vue.

The change is pretty straightforward, but the hard decision was where to put the patterns for Vue.

I opted for adding them before the `*html` ones. My reasoning was that most Vue developers will have installed the `vim-vue` plugin, that sets the filetype as `vue.html.javascript.css`. If the `*html` pattern is before the Vue ones, it will match first (and do the indentation thing, that seems less useful in a Vue file).

On the other hand, I think most users of this plugin will work on plain HTML files (maybe?) and the plugin will have to step over the three Vue patterns all the time. I don't think it will matter performance-wise, but it's something to take into account.

Anyway, let me know what you think. And thanks a lot for the help!