### PR TITLE
Add option to open proxy buffer in new tab

### DIFF
--- a/autoload/inline_edit/proxy.vim
+++ b/autoload/inline_edit/proxy.vim
@@ -115,7 +115,12 @@ function! s:CreateProxyBuffer(proxy, lines)
   let &readonly = 0
 
   if g:inline_edit_proxy_type == 'scratch'
-    exe 'silent new'
+    if g:inline_edit_open_in_tab
+      exe 'silent tabe'
+    else
+      exe 'silent new'
+    endif
+
     setlocal buftype=acwrite
     setlocal bufhidden=wipe
     call append(0, lines)

--- a/autoload/inline_edit/proxy.vim
+++ b/autoload/inline_edit/proxy.vim
@@ -115,11 +115,7 @@ function! s:CreateProxyBuffer(proxy, lines)
   let &readonly = 0
 
   if g:inline_edit_proxy_type == 'scratch'
-    if g:inline_edit_open_in_tab
-      exe 'silent tabe'
-    else
-      exe 'silent new'
-    endif
+    exe 'silent ' . g:inline_edit_new_buffer_command
 
     setlocal buftype=acwrite
     setlocal bufhidden=wipe

--- a/doc/inline_edit.txt
+++ b/doc/inline_edit.txt
@@ -181,15 +181,16 @@ executing |:make|). The drawback is that the only way to display information
 on the proxy is by hacking the statusline, which may cause issues and can't
 work reliably on all statuslines.
 
-                                                     *g:inline_edit_open_in_tab*
+                                              *g:inline_edit_new_buffer_command*
 >
-    let g:inline_edit_open_in_tab = 1
+    let g:inline_edit_new_buffer_command = 'tabedit'
 <
 
-Default value: 0
+Default value: 'new'
 
-If this variable is set to 1, the temporary proxy will be open in a new tab.
-If it's 0, a split will be used.
+This variable is set to the command that will be used to open the proxy
+buffer.  You can use any buffer-opening command like "new", "rightbelow
+vertical new", etc.
  
 
 ==============================================================================

--- a/doc/inline_edit.txt
+++ b/doc/inline_edit.txt
@@ -181,6 +181,16 @@ executing |:make|). The drawback is that the only way to display information
 on the proxy is by hacking the statusline, which may cause issues and can't
 work reliably on all statuslines.
 
+                                                     *g:inline_edit_open_in_tab*
+>
+    let g:inline_edit_open_in_tab = 1
+<
+
+Default value: 0
+
+If this variable is set to 1, the temporary proxy will be open in a new tab.
+If it's 0, a split will be used.
+ 
 
 ==============================================================================
 EXTENDING                                                *inline-edit-extending*

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -26,6 +26,10 @@ if index(['scratch', 'tempfile'], g:inline_edit_proxy_type) < 0
   echoerr 'Inline Edit: Proxy type can''t be "'.g:inline_edit_proxy_type.'". Needs to be one of: scratch, tempfile'
 endif
 
+if !exists('g:inline_edit_open_in_tab')
+  let g:inline_edit_open_in_tab = 0
+endif
+
 " Default patterns
 call add(g:inline_edit_patterns, {
       \ 'main_filetype': 'markdown',

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -26,8 +26,8 @@ if index(['scratch', 'tempfile'], g:inline_edit_proxy_type) < 0
   echoerr 'Inline Edit: Proxy type can''t be "'.g:inline_edit_proxy_type.'". Needs to be one of: scratch, tempfile'
 endif
 
-if !exists('g:inline_edit_open_in_tab')
-  let g:inline_edit_open_in_tab = 0
+if !exists('g:inline_edit_new_buffer_command')
+  let g:inline_edit_new_buffer_command = 'new'
 endif
 
 " Default patterns


### PR DESCRIPTION
This is the first thing that I looked in the documentation, so I guess it can be useful.

You can set

```vim
let g:inline_edit_open_in_tab = 1
```

to use a new tab instead of a split when calling `InlineEdit`.