### PR TITLE
Use `fnameescape` instead of `escape`

### DIFF
--- a/autoload/inline_edit/proxy.vim
+++ b/autoload/inline_edit/proxy.vim
@@ -154,7 +154,7 @@ function! s:UpdateProxyBuffer(proxy)
         \ a:proxy.end)
 
   if g:inline_edit_proxy_type == 'scratch'
-    silent exec 'keepalt file ' . escape(a:proxy.description, '[ ')
+    silent exec 'keepalt file ' . fnameescape(a:proxy.description)
   elseif g:inline_edit_proxy_type == 'tempfile'
     if g:inline_edit_modify_statusline
       if &statusline =~ '%[fF]'


### PR DESCRIPTION
`fnameescape` properly escapes all special characters in the filename that Vim may specially interpret.

I need this because I'm using [Textern](https://github.com/jlebon/textern) and it uses the URL as the filename - resulting in weird characters in it...