### PR TITLE
Support typescript & scss in *html (vue)

### DIFF
--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -77,7 +77,7 @@ call add(g:inline_edit_patterns, {
       \ })
 
 call add(g:inline_edit_patterns, {
-      \ 'main_filetype':     '*html',
+      \ 'main_filetype':     'vue',
       \ 'sub_filetype':      'typescript',
       \ 'indent_adjustment': 1,
       \ 'start':             '<script[^>]*lang=["'']ts["''][^>]*>',
@@ -93,7 +93,7 @@ call add(g:inline_edit_patterns, {
       \ })
 
 call add(g:inline_edit_patterns, {
-      \ 'main_filetype':     '*html',
+      \ 'main_filetype':     'vue',
       \ 'sub_filetype':      'scss',
       \ 'indent_adjustment': 1,
       \ 'start':             '<style[^>]*lang=["'']scss["''][^>]*>',

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -78,10 +78,26 @@ call add(g:inline_edit_patterns, {
 
 call add(g:inline_edit_patterns, {
       \ 'main_filetype':     '*html',
+      \ 'sub_filetype':      'typescript',
+      \ 'indent_adjustment': 1,
+      \ 'start':             '<script[^>]*lang="ts"[^>]*>',
+      \ 'end':               '</script>',
+      \ })
+
+call add(g:inline_edit_patterns, {
+      \ 'main_filetype':     '*html',
       \ 'sub_filetype':      'javascript',
       \ 'indent_adjustment': 1,
       \ 'start':             '<script\>[^>]*>',
       \ 'end':               '</script>',
+      \ })
+
+call add(g:inline_edit_patterns, {
+      \ 'main_filetype':     '*html',
+      \ 'sub_filetype':      'scss',
+      \ 'indent_adjustment': 1,
+      \ 'start':             '<style[^>]*lang="scss"[^>]*>',
+      \ 'end':               '</style>',
       \ })
 
 call add(g:inline_edit_patterns, {

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -80,7 +80,7 @@ call add(g:inline_edit_patterns, {
       \ 'main_filetype':     '*html',
       \ 'sub_filetype':      'typescript',
       \ 'indent_adjustment': 1,
-      \ 'start':             '<script[^>]*lang="ts"[^>]*>',
+      \ 'start':             '<script[^>]*lang=["'']ts["''][^>]*>',
       \ 'end':               '</script>',
       \ })
 
@@ -96,7 +96,7 @@ call add(g:inline_edit_patterns, {
       \ 'main_filetype':     '*html',
       \ 'sub_filetype':      'scss',
       \ 'indent_adjustment': 1,
-      \ 'start':             '<style[^>]*lang="scss"[^>]*>',
+      \ 'start':             '<style[^>]*lang=["'']scss["''][^>]*>',
       \ 'end':               '</style>',
       \ })
 


### PR DESCRIPTION
I needed this plugin to work with ts and scss in vue, so I added them. 

NOTE:
* lang="x" in the regexes should support both " and ', however I'm not sure how to escape ' into strings in vimscript.
* The regexes might have other issues as I'm not knowledgeable on vimscript or what flavor of regex it uses
* This applies to all html files (I think), which may not be desirable. Perhaps this should be limited to vue files