### PR TITLE
Add html template to angular typescript component

### DIFF
--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -128,6 +128,13 @@ call add(g:inline_edit_patterns, {
       \ 'indent_based':  1,
       \ })
 
+call add(g:inline_edit_patterns, {
+      \ 'main_filetype': 'typescript',
+      \ 'sub_filetype':  'html',
+      \ 'start':         '^\s*template:\s*`',
+      \ 'end':           '`,'
+      \ })
+
 command! -range=0 -nargs=* -complete=filetype
       \ InlineEdit call s:InlineEdit(<count>, <q-args>)
 

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -132,7 +132,7 @@ call add(g:inline_edit_patterns, {
       \ 'main_filetype': 'typescript',
       \ 'sub_filetype':  'html',
       \ 'start':         '^\s*template:\s*`',
-      \ 'end':           '`,'
+      \ 'end':           '`\(,\|$\)'
       \ })
 
 command! -range=0 -nargs=* -complete=filetype


### PR DESCRIPTION
This allows for inline edit of angular html-templates. Angular has two ways of writing html-templates. One is in a separate html-file, and one is the inline variety. This change is obviously to enable the plugin to work on the latter.

Example
```typescript
@Component({
  selector: 'my-component',
  template: `
    <p>my-component works!</p>
    ',
})
class MyComponent
```