### PR TITLE
Angular CSS and better Angular matching

### DIFF
--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -251,6 +251,7 @@ endfunction
 " function! inline_edit#AngularHtmlTemplate() {{{2
 function! inline_edit#AngularHtmlTemplate()
   call inline_edit#PushCursor()
+  let cursor_line = line('.')
 
   try
     let [component_start, component_end] = s:CheckInsideAngularComponent()
@@ -267,8 +268,8 @@ function! inline_edit#AngularHtmlTemplate()
     let start = line('.')
     let end = search('^\s*`\(,\|$\)', 'W')
 
-    if end == 0
-      " No end quote was found
+    if end == 0 || end < cursor_line
+      " No end quote was found or end quote was above cursor
       return []
     endif
 
@@ -285,6 +286,7 @@ endfunction
 " function! inline_edit#AngularCssTemplate() {{{2
 function! inline_edit#AngularCssTemplate()
   call inline_edit#PushCursor()
+  let cursor_line = line('.')
 
   try
     let [component_start, _] = s:CheckInsideAngularComponent()
@@ -306,8 +308,8 @@ function! inline_edit#AngularCssTemplate()
     let start = line('.')
     let end = search('`\(,\|$\)', 'Wc', array_end)
 
-    if end == 0
-      " No end quote was found
+    if end == 0 || end < cursor_line
+      " No end quote was found or end quote was above cursor
       return []
     endif
 

--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -248,24 +248,20 @@ function! inline_edit#PythonMultilineString()
   return [start, end, filetype, indent]
 endfunction
 
-function s:CheckInsidePythonString()
-  return index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "pythonString") >= 0
-endfunction
 " function! inline_edit#AngularHtmlTemplate() {{{2
-
 function! inline_edit#AngularHtmlTemplate()
   call inline_edit#PushCursor()
 
   try
     normal! 0
 
-    if !CheckInsideAngularInlineHtmlTemplate()
+    if !s:CheckInsideAngularInlineHtmlTemplate()
       return []
     endif
 
     normal! $
 
-    if !CheckInsideAngularInlineHtmlTemplate()
+    if !s:CheckInsideAngularInlineHtmlTemplate()
       return []
     endif
 
@@ -277,11 +273,9 @@ function! inline_edit#AngularHtmlTemplate()
 
     normal! $
 
-    echom "start " . start_backtick . ' line ' . line('.')
     let start = line('.') + 1
-
     let end = search('`\(,\|$\)', 'W')
-    echom end
+
     if end == 0
       " No end quote was found
       return []
@@ -306,28 +300,20 @@ function! inline_edit#AngularHtmlTemplate()
   return [start, end, 'html', indent]
 endfunction
 
-function CheckInsideAngularInlineHtmlTemplate()
-  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
-  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
-  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
-  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
-  return l:inside_typescript_template && !l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
-endfunction
 " function! inline_edit#AngularCssTemplate() {{{2
-
 function! inline_edit#AngularCssTemplate()
   call inline_edit#PushCursor()
 
   try
     normal! 0
 
-    if !CheckInsideAngularInlineCssTemplate()
+    if !s:CheckInsideAngularInlineCssTemplate()
       return []
     endif
 
     normal! $
 
-    if !CheckInsideAngularInlineCssTemplate()
+    if !s:CheckInsideAngularInlineCssTemplate()
       return []
     endif
 
@@ -339,11 +325,9 @@ function! inline_edit#AngularCssTemplate()
 
     normal! $
 
-    echom "start " . start_backtick . ' line ' . line('.')
     let start = line('.') + 1
 
     let end = search('`\(,\|$\)', 'W')
-    echom end
     if end == 0
       " No end quote was found
       return []
@@ -368,10 +352,22 @@ function! inline_edit#AngularCssTemplate()
   return [start, end, 'css', indent]
 endfunction
 
-function CheckInsideAngularInlineCssTemplate()
+function s:CheckInsidePythonString()
+  return index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "pythonString") >= 0
+endfunction
+
+function s:CheckInsideAngularInlineCssTemplate()
   let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
   let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
   let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
   let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
   return l:inside_typescript_template && l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
+endfunction
+
+function s:CheckInsideAngularInlineHtmlTemplate()
+  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
+  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
+  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
+  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
+  return l:inside_typescript_template && !l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
 endfunction

--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -263,7 +263,8 @@ function! inline_edit#AngularHtmlTemplate()
       return []
     endif
 
-    let start = line('.') + 1
+    normal! j0
+    let start = line('.')
     let end = search('^\s*`\(,\|$\)', 'W')
 
     if end == 0
@@ -296,13 +297,14 @@ function! inline_edit#AngularCssTemplate()
       return []
     endif
 
-    let start_backtick = search('`', 'bWe', array_start)
+    let start_backtick = search('`', 'bWec', array_start)
     if start_backtick == 0
       return []
     endif
 
-    let start = line('.') + 1
-    let end = search('`\(,\|$\)', 'W', array_end)
+    normal! j0
+    let start = line('.')
+    let end = search('`\(,\|$\)', 'Wc', array_end)
 
     if end == 0
       " No end quote was found
@@ -418,7 +420,7 @@ function! s:PosInside(current, start, end) abort
     return 1
   elseif current_line == start_line && current_line <= end_line && current_col > start_col
     return 1
-  elseif current_line == end_line && current_line => start_line && current_col < end_col
+  elseif current_line == end_line && current_line >= start_line && current_col < end_col
     return 1
   else
     return 0

--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -275,16 +275,7 @@ function! inline_edit#AngularHtmlTemplate()
     call inline_edit#PopCursor()
   endtry
 
-  let lines = join(getline(start, end), "\n")
-
-  let indent = indent(start)
-  for i in range(start + 1, end)
-    let current_indent = indent(i)
-    " Get the minimum indent of the non-blank lines
-    if current_indent < indent && getline(i) !~? '^\s*$'
-      let indent = current_indent
-    endif
-  endfor
+  let indent = s:GetCommonIndent(start, end)
 
   return [start, end, 'html', indent]
 endfunction
@@ -318,16 +309,7 @@ function! inline_edit#AngularCssTemplate()
     call inline_edit#PopCursor()
   endtry
 
-  let lines = join(getline(start, end), "\n")
-
-  let indent = indent(start)
-  for i in range(start + 1, end)
-    let current_indent = indent(i)
-    " Get the minimum indent of the non-blank lines
-    if current_indent < indent && getline(i) !~? '^\s*$'
-      let indent = current_indent
-    endif
-  endfor
+  let indent = s:GetCommonIndent(start, end)
 
   return [start, end, 'css', indent]
 endfunction
@@ -337,17 +319,46 @@ function s:CheckInsidePythonString()
 endfunction
 
 function s:CheckInsideAngularInlineCssTemplate()
-  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
-  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
-  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
-  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
-  return l:inside_typescript_template && l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
+  let syntax_groups = map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')
+
+  let inside_typescript_template = index(syntax_groups, "typescriptTemplate") >= 0
+  let inside_typescript_array = index(syntax_groups, "typescriptArray") >= 0
+  let inside_typescript_object_literal = index(syntax_groups, "typescriptObjectLiteral") >= 0
+  let inside_typescript_object_func_call_arg = index(syntax_groups, "typescriptFuncCallArg") >= 0
+
+  return
+        \ inside_typescript_template &&
+        \ inside_typescript_array &&
+        \ inside_typescript_object_literal &&
+        \ inside_typescript_object_func_call_arg
 endfunction
 
 function s:CheckInsideAngularInlineHtmlTemplate()
-  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
-  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
-  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
-  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
-  return l:inside_typescript_template && !l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
+  let syntax_groups = map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")')
+
+  let inside_typescript_template = index(syntax_groups, "typescriptTemplate") >= 0
+  let inside_typescript_array = index(syntax_groups, "typescriptArray") >= 0
+  let inside_typescript_object_literal = index(syntax_groups, "typescriptObjectLiteral") >= 0
+  let inside_typescript_object_func_call_arg = index(syntax_groups, "typescriptFuncCallArg") >= 0
+
+  return
+        \ inside_typescript_template &&
+        \ !inside_typescript_array &&
+        \ inside_typescript_object_literal &&
+        \ inside_typescript_object_func_call_arg
+endfunction
+
+function s:GetCommonIndent(start, end)
+  let indent = indent(a:start)
+
+  for i in range(a:start + 1, a:end)
+    let current_indent = indent(i)
+
+    " Get the minimum indent of the non-blank lines
+    if current_indent < indent && getline(i) !~? '^\s*$'
+      let indent = current_indent
+    endif
+  endfor
+
+  return indent
 endfunction

--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -251,3 +251,127 @@ endfunction
 function s:CheckInsidePythonString()
   return index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "pythonString") >= 0
 endfunction
+" function! inline_edit#AngularHtmlTemplate() {{{2
+
+function! inline_edit#AngularHtmlTemplate()
+  call inline_edit#PushCursor()
+
+  try
+    normal! 0
+
+    if !CheckInsideAngularInlineHtmlTemplate()
+      return []
+    endif
+
+    normal! $
+
+    if !CheckInsideAngularInlineHtmlTemplate()
+      return []
+    endif
+
+    let start_backtick = search('^\s*template:\s*`', 'bW')
+
+    if start_backtick == 0
+      return []
+    endif
+
+    normal! $
+
+    echom "start " . start_backtick . ' line ' . line('.')
+    let start = line('.') + 1
+
+    let end = search('`\(,\|$\)', 'W')
+    echom end
+    if end == 0
+      " No end quote was found
+      return []
+    endif
+
+    let end -= 1
+  finally
+    call inline_edit#PopCursor()
+  endtry
+
+  let lines = join(getline(start, end), "\n")
+
+  let indent = indent(start)
+  for i in range(start + 1, end)
+    let current_indent = indent(i)
+    " Get the minimum indent of the non-blank lines
+    if current_indent < indent && getline(i) !~? '^\s*$'
+      let indent = current_indent
+    endif
+  endfor
+
+  return [start, end, 'html', indent]
+endfunction
+
+function CheckInsideAngularInlineHtmlTemplate()
+  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
+  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
+  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
+  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
+  return l:inside_typescript_template && !l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
+endfunction
+" function! inline_edit#AngularCssTemplate() {{{2
+
+function! inline_edit#AngularCssTemplate()
+  call inline_edit#PushCursor()
+
+  try
+    normal! 0
+
+    if !CheckInsideAngularInlineCssTemplate()
+      return []
+    endif
+
+    normal! $
+
+    if !CheckInsideAngularInlineCssTemplate()
+      return []
+    endif
+
+    let start_backtick = search('`', 'bW')
+
+    if start_backtick == 0
+      return []
+    endif
+
+    normal! $
+
+    echom "start " . start_backtick . ' line ' . line('.')
+    let start = line('.') + 1
+
+    let end = search('`\(,\|$\)', 'W')
+    echom end
+    if end == 0
+      " No end quote was found
+      return []
+    endif
+
+    let end -= 1
+  finally
+    call inline_edit#PopCursor()
+  endtry
+
+  let lines = join(getline(start, end), "\n")
+
+  let indent = indent(start)
+  for i in range(start + 1, end)
+    let current_indent = indent(i)
+    " Get the minimum indent of the non-blank lines
+    if current_indent < indent && getline(i) !~? '^\s*$'
+      let indent = current_indent
+    endif
+  endfor
+
+  return [start, end, 'css', indent]
+endfunction
+
+function CheckInsideAngularInlineCssTemplate()
+  let l:inside_typescript_template = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptTemplate") >= 0
+  let l:inside_typescript_array = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptArray") >= 0
+  let l:inside_typescript_object_literal = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptObjectLiteral") >= 0
+  let l:inside_typescript_object_func_call_arg = index(map(synstack(line('.'), col('.')), 'synIDattr(v:val, "name")'), "typescriptFuncCallArg") >= 0
+  return l:inside_typescript_template && l:inside_typescript_array && l:inside_typescript_object_literal && l:inside_typescript_object_func_call_arg
+endfunction

--- a/autoload/inline_edit.vim
+++ b/autoload/inline_edit.vim
@@ -253,28 +253,17 @@ function! inline_edit#AngularHtmlTemplate()
   call inline_edit#PushCursor()
 
   try
-    normal! 0
-
     if !s:CheckInsideAngularInlineHtmlTemplate()
       return []
     endif
 
-    normal! $
-
-    if !s:CheckInsideAngularInlineHtmlTemplate()
-      return []
-    endif
-
-    let start_backtick = search('^\s*template:\s*`', 'bW')
-
+    let start_backtick = search('^\s*template:\s*`\s*$', 'bWe')
     if start_backtick == 0
       return []
     endif
 
-    normal! $
-
     let start = line('.') + 1
-    let end = search('`\(,\|$\)', 'W')
+    let end = search('^\s*`\(,\|$\)', 'W')
 
     if end == 0
       " No end quote was found
@@ -305,20 +294,11 @@ function! inline_edit#AngularCssTemplate()
   call inline_edit#PushCursor()
 
   try
-    normal! 0
-
-    if !s:CheckInsideAngularInlineCssTemplate()
-      return []
-    endif
-
-    normal! $
-
     if !s:CheckInsideAngularInlineCssTemplate()
       return []
     endif
 
     let start_backtick = search('`', 'bW')
-
     if start_backtick == 0
       return []
     endif

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,0 +1,19 @@
+@Component({
+  selector: 'my-component',
+  template: `<p class="my-p">My component works!</p>`,
+  styles: [
+    `
+      .my-p {
+        color: orange;
+      }
+    `,
+  ],
+})
+
+@Component({
+  selector: 'my-component',
+  template: `
+    <p>my-component works!</p>
+    `,
+})
+class MyComponent

--- a/example/example.ts
+++ b/example/example.ts
@@ -10,7 +10,9 @@
       .my-div {
         color: green;
       }
+    `, `
     `,
+    ``
   ],
 })
 
@@ -18,6 +20,9 @@
   selector: 'my-component',
   template: `
     <p>my-component works!</p>
+    `,
+
+  template: `
     `,
 })
 class MyComponent

--- a/example/example.ts
+++ b/example/example.ts
@@ -6,6 +6,10 @@
       .my-p {
         color: orange;
       }
+    `, `
+      .my-div {
+        color: green;
+      }
     `,
   ],
 })

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -131,8 +131,13 @@ call add(g:inline_edit_patterns, {
 call add(g:inline_edit_patterns, {
       \ 'main_filetype': 'typescript',
       \ 'sub_filetype':  'html',
-      \ 'start':         '^\s*template:\s*`',
-      \ 'end':           '`\(,\|$\)'
+      \ 'callback':      'inline_edit#AngularHtmlTemplate'
+      \ })
+
+call add(g:inline_edit_patterns, {
+      \ 'main_filetype': 'typescript',
+      \ 'sub_filetype':  'css',
+      \ 'callback':      'inline_edit#AngularCssTemplate'
       \ })
 
 command! -range=0 -nargs=* -complete=filetype


### PR DESCRIPTION
Some fixes and improvements over https://github.com/AndrewRadev/inline_edit.vim/pull/28

Checking syntax groups works for python, but in this case, I'd look for the `@Component({` that surrounds it, because it would be more precise. I've also added an example file with some edge cases to experiment with. I should really sit down and write automated tests instead, I'll get around to it at some point.