### PR TITLE
fix: Opening tempfile now respects the opening command setting

### DIFF
--- a/autoload/inline_edit/proxy.vim
+++ b/autoload/inline_edit/proxy.vim
@@ -172,7 +172,7 @@ function! s:CreateProxyBuffer(proxy, lines)
     $delete _
     set nomodified
   elseif g:inline_edit_proxy_type == 'tempfile'
-    exe 'silent noswapfile split ' . tempname()
+    exe 'silent noswapfile ' . g:inline_edit_new_buffer_command . ' ' . tempname()
     call append(0, lines)
     $delete _
     write


### PR DESCRIPTION
I noticed, that using a tempfile instead of a scratch buffer, i could not open the tempfile in another tab, or any other specified way for that matter. I found, that before, the tempbuffer logic just didn't use the open command config. This PR fixes that.