### PR TITLE
Add support for vscode-neovim

### DIFF
--- a/autoload/inline_edit/proxy.vim
+++ b/autoload/inline_edit/proxy.vim
@@ -184,6 +184,7 @@ function! s:CreateProxyBuffer(proxy, lines)
     $delete _
     write
   elseif g:inline_edit_proxy_type == 'vscode'
+    Vsplit
     let script =<< EOF
       async function createFileIfNotExists(filePath) {
           const content = args.lines.join('\n');

--- a/plugin/inline_edit.vim
+++ b/plugin/inline_edit.vim
@@ -26,8 +26,8 @@ if !exists('g:inline_edit_proxy_type')
   let g:inline_edit_proxy_type = 'scratch'
 endif
 
-if index(['scratch', 'tempfile'], g:inline_edit_proxy_type) < 0
-  echoerr 'Inline Edit: Proxy type can''t be "'.g:inline_edit_proxy_type.'". Needs to be one of: scratch, tempfile'
+if index(['scratch', 'tempfile', 'vscode'], g:inline_edit_proxy_type) < 0
+  echoerr 'Inline Edit: Proxy type can''t be "'.g:inline_edit_proxy_type.'". Needs to be one of: scratch, tempfile, vscode'
 endif
 
 if !exists('g:inline_edit_new_buffer_command')


### PR DESCRIPTION
Add support for [vscode-neovim](https://github.com/vscode-neovim/vscode-neovim)

This is a hacky solution, and I'm proposing this in case it's of interest to the maintainer or someone else.
Please reject this Pull Request if you think this is out of scope for your plugin, and not worth maintaining.
I'll keep using my fork for the foreseeable future.

## Context:

At work, there are some important VSCode integrations so it makes sense to use it in place of Vim/Neovim.

Luckily, vscode-neovim is decent enough that I can get most of my plugins and configuration working alongside vscode. However, I've been wanting something like inline_edit.vim for ages, and I finally came around something that's at least usable.

This is hacky, notably due to the lack of support for BufWritePost (hence the ":w<cr>" workaround"), but it works. I'm putting this out there in case there's someone else in a similar pickle as me.

## To Set Up

Simply

```lua
if vim.g.vscode then
  vim.g.inline_edit_proxy_type = "vscode"
end
```